### PR TITLE
Update ceph.conf

### DIFF
--- a/templates/ceph.conf
+++ b/templates/ceph.conf
@@ -31,7 +31,9 @@ log file = /var/log/ceph/radosgw.log
 rgw frontends = civetweb port={{ port }}
 {% if auth_type == 'keystone' %}
 rgw keystone url = {{ auth_protocol }}://{{ auth_host }}:{{ auth_port }}/
-rgw keystone admin token = {{ admin_token }}
+rgw keystone admin user = {{ admin_user }}
+rgw keystone admin password = {{ admin_password }}
+rgw keystone admin tenant = {{ admin_tenant_name }}
 rgw keystone accepted roles = {{ user_roles }}
 rgw keystone token cache size = {{ cache_size }}
 rgw keystone revocation interval = {{ revocation_check_interval }}


### PR DESCRIPTION
Use Keystone authentication with username and password instead of unsafe admin token. 
This proposal uses default v2 Keystone API, but is possibile use v3 too as described here: http://docs.ceph.com/docs/master/radosgw/keystone/