### PR TITLE
Allow the simple Swift auth to work

### DIFF
--- a/hooks/ceph_radosgw_context.py
+++ b/hooks/ceph_radosgw_context.py
@@ -29,9 +29,10 @@ from charmhelpers.core.hookenv import (
     WARNING,
     config,
     log,
-    relation_ids,
     related_units,
     relation_get,
+    relation_ids,
+    unit_public_ip,
 )
 from charmhelpers.contrib.network.ip import (
     format_ipv6_addr,
@@ -175,7 +176,13 @@ class MonContext(context.CephContext):
             'use_syslog': str(config('use-syslog')).lower(),
             'loglevel': config('loglevel'),
             'port': port,
-            'ipv6': config('prefer-ipv6')
+            'ipv6': config('prefer-ipv6'),
+            # The public unit IP is only used in case the authentication is
+            # *Not* keystone - in which case it is used to make sure the
+            # storage endpoint returned by the built-in auth is the HAproxy
+            # (since it defaults to the port the service runs on, and that is
+            # not available externally). ~tribaal
+            'unit_public_ip': unit_public_ip(),
         }
 
         certs_path = '/var/lib/ceph/nss'

--- a/templates/ceph.conf
+++ b/templates/ceph.conf
@@ -31,6 +31,9 @@ log file = /var/log/ceph/radosgw.log
 rgw frontends = civetweb port={{ port }}
 {% if auth_type == 'keystone' %}
 rgw keystone url = {{ auth_protocol }}://{{ auth_host }}:{{ auth_port }}/
+{% else %}
+rgw swift url = http://{{ unit_public_ip }}
+{% endif %}
 {% if auth_keystone_v3_supported and api_version == '3' -%}
 rgw keystone api version = 3
 rgw keystone admin user = {{ admin_user }}


### PR DESCRIPTION
Incase we do *not* use keystone as an authentication mechanism, let the
built-in authentication work with this charm.

Without this change, the Swift authentication itself will work, but the
X-Storage-URL header will point to the port the storage daemon listens
on - which is not open in the firewall (70).

This change instead forces the URL to be "the unit's public IP" with the
default port (80), on which haproxy is listening, and will do the right
thing.

Signed-off-by: Christopher Glass <chris.glass@canonical.com>