### PR TITLE
Fix YAML lint errors

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -171,30 +171,6 @@ options:
     description: |
       Default multicast port number that will be used to communicate between
       HA Cluster nodes.
-  haproxy-server-timeout:
-    type: int
-    default:
-    description: |
-      Server timeout configuration in ms for haproxy, used in HA
-      configurations. If not provided, default value of 90000ms is used.
-  haproxy-client-timeout:
-    type: int
-    default:
-    description: |
-      Client timeout configuration in ms for haproxy, used in HA
-      configurations. If not provided, default value of 90000ms is used.
-  haproxy-queue-timeout:
-    type: int
-    default:
-    description: |
-      Queue timeout configuration in ms for haproxy, used in HA
-      configurations. If not provided, default value of 9000ms is used.
-  haproxy-connect-timeout:
-    type: int
-    default:
-    description: |
-      Connect timeout configuration in ms for haproxy, used in HA
-      configurations. If not provided, default value of 9000ms is used.
   # Network config (by default all access is over 'private-address')
   os-admin-network:
     type: string
@@ -320,4 +296,3 @@ options:
     description: |
       SSL CA to use with the certificate and key provided - this is only
       required if you are providing a privately signed ssl_cert and ssl_key.
-


### PR DESCRIPTION
yamllint reported hard errors
config.yaml
  1:1       warning  missing document start "---"  (document-start)
  63:14     warning  truthy value is not quoted  (truthy)
  85:14     warning  truthy value is not quoted  (truthy)
  145:14    warning  truthy value is not quoted  (truthy)
  150:14    warning  truthy value is not quoted  (truthy)
  279:3     error    duplication of key "haproxy-server-timeout" in
mapping  (key-duplicates)
  285:3     error    duplication of key "haproxy-client-timeout" in
mapping  (key-duplicates)
  291:3     error    duplication of key "haproxy-queue-timeout" in
mapping  (key-duplicates)
  297:3     error    duplication of key "haproxy-connect-timeout" in
mapping  (key-duplicates)
  323:1     error    too many blank lines (1 > 0)  (empty-lines)

The warnings remain
config.yaml
  1:1       warning  missing document start "---"  (document-start)
  63:14     warning  truthy value is not quoted  (truthy)
  85:14     warning  truthy value is not quoted  (truthy)
  145:14    warning  truthy value is not quoted  (truthy)
  150:14    warning  truthy value is not quoted  (truthy)